### PR TITLE
New humantime library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/serde-humantime/0.1.1/serde_humantime"
 readme = "README.md"
 
 [dependencies]
-humantime = "1.0"
+humantime = "1.1.0-beta.2"
 serde = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/serde-humantime/0.1.1/serde_humantime"
 readme = "README.md"
 
 [dependencies]
-humantime = "=1.1.0-beta.3"
+humantime = "1.1.0"
 serde = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/serde-humantime/0.1.1/serde_humantime"
 readme = "README.md"
 
 [dependencies]
-humantime = "1.1.0-beta.2"
+humantime = "=1.1.0-beta.3"
 serde = "1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,4 +175,25 @@ mod test {
         let foo = serde_json::from_str::<Foo>(json).unwrap();
         assert_eq!(foo.time.into_inner(), None);
     }
+
+    #[test]
+    fn unwrapped_option() {
+        #[derive(Deserialize)]
+        struct Foo {
+            #[serde(with = "super", default)]
+            time: Option<Duration>,
+        }
+
+        let json = r#"{"time": "15 seconds"}"#;
+        let foo = serde_json::from_str::<Foo>(json).unwrap();
+        assert_eq!(foo.time, Some(Duration::from_secs(15)));
+
+        let json = r#"{"time": null}"#;
+        let foo = serde_json::from_str::<Foo>(json).unwrap();
+        assert_eq!(foo.time, None);
+
+        let json = r#"{}"#;
+        let foo = serde_json::from_str::<Foo>(json).unwrap();
+        assert_eq!(foo.time, None);
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,7 @@
-use serde::ser::{Serializer};
-use serde::de::{Deserializer};
+use std::fmt;
+use serde::ser::{Serializer, Serialize};
+use serde::de::{Deserializer, Error as DeError, Visitor};
+use std::marker::PhantomData;
 
 
 pub trait Sealed {
@@ -14,4 +16,68 @@ pub trait Sealed {
 ///
 /// This trait is currently sealed. This might change in future.
 pub trait HumanTime: Sealed {
+}
+
+impl<T: HumanTime> HumanTime for Option<T> {}
+
+impl<T: Sealed> Sealed for Option<T> {
+    fn encode<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        struct Data<'a, V: 'a>(&'a V) where V: Sealed;
+
+        impl<'a, V: Sealed + 'a> Serialize for Data<'a, V> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where S: Serializer
+            {
+                self.0.encode(serializer)
+            }
+        }
+
+        match *self {
+            Some(ref value) => serializer.serialize_some(&Data(value)),
+            None => serializer.serialize_none(),
+        }
+    }
+    fn decode<'de, D>(deserializer: D) -> Result<Self, D::Error>
+        where Self: Sized,
+              D: Deserializer<'de>,
+    {
+        struct OptionVisitor<T> {
+            marker: PhantomData<T>,
+        }
+
+        impl<'de, T: Sealed> Visitor<'de> for OptionVisitor<T> {
+            type Value = Option<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
+            {
+                formatter.write_str("option")
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> Result<Option<T>, E>
+                where E: DeError,
+            {
+                Ok(None)
+            }
+
+            #[inline]
+            fn visit_none<E>(self) -> Result<Option<T>, E>
+                where E: DeError,
+            {
+                Ok(None)
+            }
+
+            #[inline]
+            fn visit_some<D>(self, deserializer: D)
+                -> Result<Option<T>, D::Error>
+                where D: Deserializer<'de>,
+            {
+                T::decode(deserializer).map(Some)
+            }
+        }
+
+        deserializer.deserialize_option(OptionVisitor { marker: PhantomData })
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,17 @@
+use serde::ser::{Serializer};
+use serde::de::{Deserializer};
+
+
+pub trait Sealed {
+    fn encode<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer;
+    fn decode<'de, D>(deserializer: D) -> Result<Self, D::Error>
+        where Self: Sized,
+              D: Deserializer<'de>;
+}
+
+/// A value serializeable using humantime crate
+///
+/// This trait is currently sealed. This might change in future.
+pub trait HumanTime: Sealed {
+}


### PR DESCRIPTION
Hi,

This PR does two things:

1. Uses trait to be able to (de)serialize multiple types, in particular this allows working with `Option<Duration>` without a wrapper
2. Adds `SystemTime` support and serialize for Duration as these things are supported by new humantime crate (beta version yet)

I'm not sure about `De`, should it be deprecated? Or just remove it and bump a major version?